### PR TITLE
[WIP] fix compilation/setup/python3 for M1 map

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,7 @@ env = Environment(CPPPATH = include_dirs,
 		  LIBS = libs, SHLIBPREFIX = "", 
 		  ENV  = os.environ)
 
-env_noopt = env.Copy(CCFLAGS = flags_noopt, CXXFLAGS = flags_noopt)
+env_noopt = env.Clone(CCFLAGS = flags_noopt, CXXFLAGS = flags_noopt)
 
 Export("env", "env_noopt")
 SConscript("camfr/SConscript")

--- a/camfr/camfr_wrap.cpp
+++ b/camfr/camfr_wrap.cpp
@@ -577,7 +577,7 @@ BOOST_PYTHON_MODULE(_camfr)
   implicitly_convertible<Scatterer,Term>();
   implicitly_convertible<Stack,Term>();
 
-  import_array();
+  if (_import_array() < 0) {PyErr_Print(); PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import"); return; }
 
   to_python_converter<cVector, cVector_to_python>();
   to_python_converter<cMatrix, cMatrix_to_python>();

--- a/camfr/geometry.py
+++ b/camfr/geometry.py
@@ -134,7 +134,7 @@ class Rectangle:
 
     def __init__(self, p1, p2, mat):
         p = [p1, p2]
-        p.sort(sort_point)
+        p.sort(key=lambda p: p.x)
         self.p1, self.p2 = p
         self.mat = mat
         self.type = "Rectangle"
@@ -210,7 +210,7 @@ class Triangle:
 
     def __init__(self, p1, p2, p3, mat):
         self.p = [p1, p2, p3]
-        self.p.sort(sort_point)
+        self.p.sort(key=lambda p: p.x)
         self.p1, self.p2, self.p3 = self.p
         self.mat = mat
         self.type = "Triangle"

--- a/camfr/matplotlib_section.py
+++ b/camfr/matplotlib_section.py
@@ -123,7 +123,7 @@ def __Section_plot(self, field="Ex", mode=0, dx=0.100, dy=0.100, annotations=Tru
     # create the complementary array of CAMFR fields
     try:
         cfield = [fieldopts[a] for a in    [b.lower() for b in field]  ]
-    except KeyError, k:
+    except KeyError as k:
         raise ValueError(  "Unrecognized value %s found for the `field` argument. " % k  + "The following options are valid: %s"  % fieldopts.keys()  )
     #end try(fieldopts)
     

--- a/machine_cfg.py.MacOSX-brew
+++ b/machine_cfg.py.MacOSX-brew
@@ -1,0 +1,64 @@
+# This Python script contains all the machine dependent settings
+# needed during the build process.
+
+# installation on python 3 with brew
+# brew install scons
+# brew install blitz
+# brew install lapack
+# brew install boost-python3
+# brew install texlive
+
+# define python version with pyenv and define virtualenv with venv
+
+#
+# is building on ARM mac book pro Monterey 12.1
+
+# Demis D. John, 2018-02-27, demis@ucsb.edu
+############################################
+
+# Compilers to be used.
+
+cc  = "clang"
+cxx = "clang++"
+f77 = "gfortran"
+
+link = cxx
+link_flags = " -undefined dynamic_lookup -dynamic -stdlib=libc++ -o camfr/_camfr.so -stdlib=libc++"  #-dynamic -single_module -undefined dynamic_lookup"
+# Compiler flags.
+#
+# Note: for the Fortran name definition you can define one of the following
+#       preprocessor macros:
+#
+#           FORTRAN_SYMBOLS_WITHOUT_TRAILING_UNDERSCORES
+#           FORTRAN_SYMBOLS_WITH_SINGLE_TRAILING_UNDERSCORE
+#           FORTRAN_SYMBOLS_WITH_DOUBLE_TRAILING_UNDERSCORES
+
+base_flags = " -DFORTRAN_SYMBOLS_WITH_DOUBLE_TRAILING_UNDERSCORE -DNDEBUG"
+
+flags_noopt = base_flags
+
+fflags = base_flags + " -O2 -pipe -fomit-frame-pointer -funroll-loops -fstrict-aliasing -g -fPIC -stdlib=libc++"
+flags = fflags + " -ftemplate-depth-60"
+
+# Include directories.
+#   MacPorts directories, MacPorts python2.7
+include_dirs = ["/opt/local/include",
+                "/opt/homebrew/Cellar//boost/1.78.0_1/include/",
+                "/opt/homebrew/Cellar/blitz/1.0.2/include/",
+                "~/.pyenv/versions/3.9.11/include/python3.9", "venv/lib/python3.9/site-packages"]
+
+library_dirs = [ "/opt/homebrew/Cellar//boost/1.78.0_1/lib", "/opt/homebrew/Cellar/boost-python3/1.78.0/lib",
+                 "/opt/homebrew/Cellar/blitz/1.0.2/lib","/opt//homebrew/Cellar/gcc/11.3.0/lib/gcc/11/"
+              ]
+
+# Library names.
+libs = ["libboost_python39", "libblitz", "liblapack","libblas","gfortran"]
+
+
+# Command to strip library of excess symbols:
+dllsuffix = ".so"
+strip_command = ""#"strip --strip-unneeded camfr/_camfr" + dllsuffix
+
+# Extra files to copy into installation directory.
+#   This PDF should be Built first or the command will fail.
+extra_files = [("doc", ["docs/camfr.pdf"])]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+Image==1.5.33
+ImageFilter==0.1.0
+matplotlib==3.5.2
+MLab==1.1.4
+Numeric==24.2
+numpy==1.22.3
+Pillow==9.1.0
+pymat==0.0.2
+scipy==1.8.0

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 #! /usr/bin/env python
 
-# To Do:
-#   Must run the following command afterwards:
-#        mv /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/camfr/_camfr.dylib  /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/camfr/_camfr.so
-
-
 from distutils.core import setup
 from distutils.util import byte_compile
 from distutils.command.build import build
@@ -37,18 +32,8 @@ class camfr_build(build):
 class camfr_install_data(install_data):
   def run(self):
 
-    # Byte-compile Python files.
-
     scripts = []
-          
-    for i in self.data_files:
-      for j in i[1]:
-        if j[-2:] == "py":
-          scripts.append(j)
-          i[1].append(j+'c')
-
-    byte_compile(scripts)
-      
+                
     # Change install dir to library dir.
     
     install_cmd = self.get_finalized_command('install')
@@ -78,6 +63,7 @@ setup(name         = "camfr",
                              "camfr/material.py",
                              "camfr/RCLED.py",
                              "camfr/GARCLED.py",
+                             "camfr/matplotlib_section.py",
                              "visualisation/camfr_PIL.py",
                              "visualisation/camfr_matlab.py",
                              "visualisation/camfr_tk.py",

--- a/testsuite/ADR_solver.py
+++ b/testsuite/ADR_solver.py
@@ -44,7 +44,7 @@ class ADR_solver(unittest.TestCase):
         free_tmps()
         set_solver(track)
 
-        self.failUnless(mode0_pass)
+        self.assertTrue(mode0_pass)
 
 suite = unittest.makeSuite(ADR_solver, 'test')        
 

--- a/testsuite/PhC_splitter.py
+++ b/testsuite/PhC_splitter.py
@@ -72,7 +72,7 @@ class PhC_splitter(unittest.TestCase):
 
         while wg.mode(guided).kz().real <= 0:
             guided += 1
-        for i in arange(guided,2*N()):
+        for i in range(guided,2*N()):
             if (abs(wg.mode(i).kz().imag) < abs(wg.mode(guided).kz().imag)):
                 if wg.mode(i).kz().real > 0:
                     guided = i
@@ -115,7 +115,7 @@ class PhC_splitter(unittest.TestCase):
 
         set_lower_wall(slab_E_wall)
         
-        self.failUnless(guided_kz_pass and R_pass and E_field_pass)
+        self.assertTrue(guided_kz_pass and R_pass and E_field_pass)
 
 suite = unittest.makeSuite(PhC_splitter, 'test')        
 

--- a/testsuite/SpE.py
+++ b/testsuite/SpE.py
@@ -64,7 +64,7 @@ class SpE(unittest.TestCase):
 
         set_circ_PML(0)
        
-        self.failUnless(eta_pass)
+        self.assertTrue(eta_pass)
 
 suite = unittest.makeSuite(SpE, 'test')        
 

--- a/testsuite/TEM_field.py
+++ b/testsuite/TEM_field.py
@@ -52,7 +52,7 @@ class TEM_field(unittest.TestCase):
 
         set_polarisation(TE)
        
-        self.failUnless(f1_pass and f2_pass and f3_pass)
+        self.assertTrue(f1_pass and f2_pass and f3_pass)
 
 suite = unittest.makeSuite(TEM_field, 'test')        
 

--- a/testsuite/VCSEL.py
+++ b/testsuite/VCSEL.py
@@ -95,7 +95,7 @@ class VCSEL(unittest.TestCase):
 
         set_circ_PML(0)
 
-        self.failUnless(wavelength_pass and gain_pass)
+        self.assertTrue(wavelength_pass and gain_pass)
 
 suite = unittest.makeSuite(VCSEL, 'test')        
 

--- a/testsuite/backward.py
+++ b/testsuite/backward.py
@@ -45,7 +45,7 @@ class backward(unittest.TestCase):
 
         set_backward_modes(0)
            
-        self.failUnless(R_pass and T_pass)
+        self.assertTrue(R_pass and T_pass)
 
 suite = unittest.makeSuite(backward, 'test')
 

--- a/testsuite/backward2.py
+++ b/testsuite/backward2.py
@@ -45,7 +45,7 @@ class backward2(unittest.TestCase):
         set_circ_PML(0)   
         set_backward_modes(0)
            
-        self.failUnless(n_eff_pass)
+        self.assertTrue(n_eff_pass)
 
 suite = unittest.makeSuite(backward2, 'test')
 

--- a/testsuite/backward3.py
+++ b/testsuite/backward3.py
@@ -59,7 +59,7 @@ class backward3(unittest.TestCase):
         set_lower_wall(slab_E_wall)
         set_orthogonal(True)
         
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(backward3, 'test')
 

--- a/testsuite/blazed_grating.py
+++ b/testsuite/blazed_grating.py
@@ -118,7 +118,7 @@ class blazed_grating(unittest.TestCase):
         set_lower_PML(0)
         set_upper_PML(0)
 
-        self.failUnless(R_pass and T_pass)
+        self.assertTrue(R_pass and T_pass)
 
 suite = unittest.makeSuite(blazed_grating, 'test')        
 

--- a/testsuite/blochstack.py
+++ b/testsuite/blochstack.py
@@ -81,7 +81,7 @@ class blochstack(unittest.TestCase):
 
         set_upper_PML(0)
        
-        self.failUnless(R_pass and T_pass)
+        self.assertTrue(R_pass and T_pass)
 
         free_tmps()
 

--- a/testsuite/cladding.py
+++ b/testsuite/cladding.py
@@ -39,7 +39,7 @@ class cladding(unittest.TestCase):
 
         free_tmps()
       
-        self.failUnless( E_field_pass )
+        self.assertTrue( E_field_pass )
 
 suite = unittest.makeSuite(cladding, 'test')        
 

--- a/testsuite/coupled.py
+++ b/testsuite/coupled.py
@@ -45,7 +45,7 @@ class coupled(unittest.TestCase):
 
         free_tmps()
            
-        self.failUnless(n_eff_0_pass and n_eff_1_pass)
+        self.assertTrue(n_eff_0_pass and n_eff_1_pass)
 
 suite = unittest.makeSuite(coupled, 'test')
 

--- a/testsuite/degenerate.py
+++ b/testsuite/degenerate.py
@@ -52,7 +52,7 @@ class degenerate(unittest.TestCase):
 
         free_tmps()
            
-        self.failUnless(OK)
+        self.assertTrue(OK)
 
 suite = unittest.makeSuite(degenerate, 'test')
 

--- a/testsuite/degenerate2.py
+++ b/testsuite/degenerate2.py
@@ -48,7 +48,7 @@ class degenerate2(unittest.TestCase):
         set_unstable_exp_threshold(1e-12)
         set_field_calc_heuristic(identical)
         
-        self.failUnless(T_pass)
+        self.assertTrue(T_pass)
 
 suite = unittest.makeSuite(degenerate2, 'test')
 

--- a/testsuite/degenerate3.py
+++ b/testsuite/degenerate3.py
@@ -43,7 +43,7 @@ class degenerate3(unittest.TestCase):
 
         set_unstable_exp_threshold(1e-12)
         
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(degenerate3, 'test')
 

--- a/testsuite/degenerate4.py
+++ b/testsuite/degenerate4.py
@@ -45,7 +45,7 @@ class degenerate4(unittest.TestCase):
 
         free_tmps()
         
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(degenerate4, 'test')
 

--- a/testsuite/dent.py
+++ b/testsuite/dent.py
@@ -51,7 +51,7 @@ class dent(unittest.TestCase):
         set_upper_PML(0)
         set_lower_PML(0)
            
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(dent, 'test')
 

--- a/testsuite/expressions.py
+++ b/testsuite/expressions.py
@@ -71,7 +71,7 @@ class expressions(unittest.TestCase):
 
         free_tmps()
 
-        self.failUnless(1)
+        self.assertTrue(1)
 
 suite = unittest.makeSuite(expressions, 'test')        
 

--- a/testsuite/field.py
+++ b/testsuite/field.py
@@ -52,7 +52,7 @@ class field(unittest.TestCase):
         set_upper_PML(0)
         set_lower_PML(0)
         
-        self.failUnless(f1_pass and f2_pass)
+        self.assertTrue(f1_pass and f2_pass)
 
 suite = unittest.makeSuite(field, 'test')        
 

--- a/testsuite/field.py
+++ b/testsuite/field.py
@@ -38,7 +38,7 @@ class field(unittest.TestCase):
         print(f1, "expected", f_OK)
         f1_pass = abs(f1 - f_OK) < eps.testing_eps
         
-        inc = zeros(N())
+        inc = np.zeros(N())
         inc[1] = 1
         stack.set_inc_field(inc)
 

--- a/testsuite/fw_bw.py
+++ b/testsuite/fw_bw.py
@@ -32,7 +32,7 @@ class fw_bw(unittest.TestCase):
 
         s = Stack(s1(0)+s2(1)+s1(0))
 
-        inc = zeros(N())
+        inc = np.zeros(N())
         inc[0] = 1
         s.set_inc_field(inc)
         

--- a/testsuite/fw_bw.py
+++ b/testsuite/fw_bw.py
@@ -55,7 +55,7 @@ class fw_bw(unittest.TestCase):
         set_upper_PML(0)
         set_lower_PML(0)
            
-        self.failUnless(f_pass and b_pass)
+        self.assertTrue(f_pass and b_pass)
 
 suite = unittest.makeSuite(fw_bw, 'test')
 

--- a/testsuite/gaussian.py
+++ b/testsuite/gaussian.py
@@ -47,7 +47,7 @@ class gaussian(unittest.TestCase):
         set_lower_PML(0)
         set_upper_PML(0)
            
-        self.failUnless(T_pass)
+        self.assertTrue(T_pass)
 
 suite = unittest.makeSuite(gaussian, 'test')
 

--- a/testsuite/grating.py
+++ b/testsuite/grating.py
@@ -52,7 +52,7 @@ class grating(unittest.TestCase):
         set_upper_wall(slab_E_wall)
         set_lower_wall(slab_E_wall)
            
-        self.failUnless(E1_pass and E2_pass)
+        self.assertTrue(E1_pass and E2_pass)
 
 suite = unittest.makeSuite(grating, 'test')
 

--- a/testsuite/grating2.py
+++ b/testsuite/grating2.py
@@ -69,7 +69,7 @@ class grating2(unittest.TestCase):
 
         free_tmps()
            
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(grating2, 'test')
 

--- a/testsuite/grating3.py
+++ b/testsuite/grating3.py
@@ -68,7 +68,7 @@ class grating3(unittest.TestCase):
         set_upper_PML(0)
         set_degenerate(1)
         
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(grating3, 'test')
 

--- a/testsuite/infstack.py
+++ b/testsuite/infstack.py
@@ -76,7 +76,7 @@ class infstack(unittest.TestCase):
 
         set_upper_PML(0)
        
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
         free_tmps()
 

--- a/testsuite/metal_coupler.py
+++ b/testsuite/metal_coupler.py
@@ -110,7 +110,7 @@ class metal_coupler(unittest.TestCase):
 
         free_tmps()
 
-        self.failUnless(up_pass)
+        self.assertTrue(up_pass)
 
 suite = unittest.makeSuite(metal_coupler, 'test')
 

--- a/testsuite/metal_coupler.py
+++ b/testsuite/metal_coupler.py
@@ -80,7 +80,7 @@ class metal_coupler(unittest.TestCase):
 
         guided  = 0
         campmax = 0
-        for k in arange(0,nom,1):
+        for k in np.arange(0,nom,1):
             camp = abs(waveguide.mode(k).field(Coord(d_sub+dclad+\
                                             guide_thickness/2,0,0)).E1())
             if campmax < camp:

--- a/testsuite/metal_coupler.py
+++ b/testsuite/metal_coupler.py
@@ -80,7 +80,7 @@ class metal_coupler(unittest.TestCase):
 
         guided  = 0
         campmax = 0
-        for k in np.arange(0,nom,1):
+        for k in range(0,nom,1):
             camp = abs(waveguide.mode(k).field(Coord(d_sub+dclad+\
                                             guide_thickness/2,0,0)).E1())
             if campmax < camp:
@@ -89,7 +89,7 @@ class metal_coupler(unittest.TestCase):
 
         # Set input for calculating the fields.
 
-        inc = zeros(N())
+        inc = np.zeros(N())
         inc[guided] = 1
         stack.set_inc_field(inc)
 

--- a/testsuite/metal_splitter.py
+++ b/testsuite/metal_splitter.py
@@ -79,15 +79,15 @@ class metal_splitter(unittest.TestCase):
 
         splitter.calc()
         
-        plot(cen)
-        plot(arm)
-        plot(ver)
+        #plot(cen)
+        #plot(arm)
+        #plot(ver)
         
-        inc = zeros(N())
+        inc = np.zeros(N())
         inc[0] = 1
         splitter.set_inc_field(inc)
 
-        plot(splitter)
+        #plot(splitter)
 
         R = splitter.R12(0,0)
         R_OK = 0.844654989543+0.499289083195j

--- a/testsuite/metal_splitter.py
+++ b/testsuite/metal_splitter.py
@@ -101,7 +101,7 @@ class metal_splitter(unittest.TestCase):
         set_lower_wall(slab_E_wall)
         set_upper_PML(0)
 
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(metal_splitter, 'test')        
 

--- a/testsuite/planarTE.py
+++ b/testsuite/planarTE.py
@@ -50,7 +50,7 @@ class planarTE(unittest.TestCase):
 
         free_tmps()
 
-        self.failUnless(R_pass and T_pass)
+        self.assertTrue(R_pass and T_pass)
 
 suite = unittest.makeSuite(planarTE, 'test')        
 

--- a/testsuite/planarTM.py
+++ b/testsuite/planarTM.py
@@ -50,7 +50,7 @@ class planarTE(unittest.TestCase):
 
         free_tmps()
 
-        self.failUnless(R_pass and T_pass)
+        self.assertTrue(R_pass and T_pass)
 
 suite = unittest.makeSuite(planarTE, 'test')        
 

--- a/testsuite/planar_VCSEL.py
+++ b/testsuite/planar_VCSEL.py
@@ -72,8 +72,8 @@ class planar_VCSEL(unittest.TestCase):
 
         vcsel = Stack(bottom + cavity + top)
 
-        incL = zeros(N())
-        incR = zeros(N())
+        incL = np.zeros(N())
+        incR = np.zeros(N())
         incR[0] = 1
         vcsel.set_inc_field(incL,incR)
 

--- a/testsuite/planar_VCSEL.py
+++ b/testsuite/planar_VCSEL.py
@@ -86,7 +86,7 @@ class planar_VCSEL(unittest.TestCase):
 
         free_tmps()
 
-        self.failUnless(field_pass)
+        self.assertTrue(field_pass)
 
 suite = unittest.makeSuite(planar_VCSEL, 'test')        
 

--- a/testsuite/plasmon_biosensor.py
+++ b/testsuite/plasmon_biosensor.py
@@ -74,7 +74,7 @@ class plasmon_biosensor(unittest.TestCase):
         set_lower_PML(0)
         set_orthogonal(True)
 
-        self.failUnless(T_pass)
+        self.assertTrue(T_pass)
 
 suite = unittest.makeSuite(plasmon_biosensor, 'test')
 

--- a/testsuite/polariton.py
+++ b/testsuite/polariton.py
@@ -59,7 +59,7 @@ class polariton(unittest.TestCase):
         free_tmps()
         set_polarisation(TE)
            
-        self.failUnless(kz_pass)
+        self.assertTrue(kz_pass)
 
 suite = unittest.makeSuite(polariton, 'test')
 

--- a/testsuite/polariton2.py
+++ b/testsuite/polariton2.py
@@ -63,7 +63,7 @@ class polariton2(unittest.TestCase):
         set_mode_surplus(1.5)
         set_keep_all_1D_estimates(0)
         
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(polariton2, 'test')
 

--- a/testsuite/precision.py
+++ b/testsuite/precision.py
@@ -43,7 +43,7 @@ class precision(unittest.TestCase):
         free_tmps()
         set_precision(100)
  
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(precision, 'test')
 

--- a/testsuite/rods.py
+++ b/testsuite/rods.py
@@ -59,7 +59,7 @@ class rods(unittest.TestCase):
         set_upper_PML(0)
         set_lower_PML(0)
 
-        self.failUnless(mode98_pass and mode99_pass)
+        self.assertTrue(mode98_pass and mode99_pass)
 
 suite = unittest.makeSuite(rods, 'test')        
 

--- a/testsuite/section1.py
+++ b/testsuite/section1.py
@@ -56,7 +56,7 @@ class section1(unittest.TestCase):
         set_lower_wall(slab_E_wall)
         set_upper_wall(slab_E_wall)
         
-        self.failUnless(n_eff_0_pass and n_eff_1_pass)
+        self.assertTrue(n_eff_0_pass and n_eff_1_pass)
 
 suite = unittest.makeSuite(section1, 'test')
 

--- a/testsuite/section2.py
+++ b/testsuite/section2.py
@@ -52,7 +52,7 @@ class section2(unittest.TestCase):
         set_left_wall (E_wall)
         set_right_wall(E_wall)
         
-        self.failUnless(n_eff_0_pass)
+        self.assertTrue(n_eff_0_pass)
 
 suite = unittest.makeSuite(section2, 'test')
 

--- a/testsuite/section3.py
+++ b/testsuite/section3.py
@@ -58,7 +58,7 @@ class section3(unittest.TestCase):
         set_upper_wall(slab_E_wall)
         set_lower_wall(slab_E_wall)
     
-        self.failUnless(n_eff_0_pass)
+        self.assertTrue(n_eff_0_pass)
 
 suite = unittest.makeSuite(section3, 'test')
 

--- a/testsuite/shift.py
+++ b/testsuite/shift.py
@@ -44,7 +44,7 @@ class shift(unittest.TestCase):
         set_upper_wall(slab_E_wall)
         set_lower_wall(slab_E_wall)
            
-        self.failUnless(T_pass)
+        self.assertTrue(T_pass)
 
 suite = unittest.makeSuite(shift, 'test')
 

--- a/testsuite/slab.py
+++ b/testsuite/slab.py
@@ -43,7 +43,7 @@ class slab(unittest.TestCase):
         set_lower_PML(0)
         set_polarisation(TE)
            
-        self.failUnless(n_pass)
+        self.assertTrue(n_pass)
 
 suite = unittest.makeSuite(slab, 'test')
 

--- a/testsuite/slab2.py
+++ b/testsuite/slab2.py
@@ -44,7 +44,7 @@ class slab2(unittest.TestCase):
 
         set_lower_wall(slab_E_wall)
            
-        self.failUnless(f_pass)
+        self.assertTrue(f_pass)
 
 suite = unittest.makeSuite(slab2, 'test')
 

--- a/testsuite/slab3.py
+++ b/testsuite/slab3.py
@@ -50,7 +50,7 @@ class slab3(unittest.TestCase):
 
         set_lower_wall(slab_E_wall)
            
-        self.failUnless(n0_pass and n9_pass)
+        self.assertTrue(n0_pass and n9_pass)
 
 suite = unittest.makeSuite(slab3, 'test')
 

--- a/testsuite/stack0.py
+++ b/testsuite/stack0.py
@@ -30,7 +30,7 @@ class stack0(unittest.TestCase):
         
         s = Stack(AlGaAs(0) + air(1) + AlGaAs(0))
 
-        inc = zeros(N())
+        inc = np.zeros(N())
         inc[0] = 1
         s.set_inc_field(inc)
 

--- a/testsuite/stack0.py
+++ b/testsuite/stack0.py
@@ -45,7 +45,7 @@ class stack0(unittest.TestCase):
 
         free_tmps()
         
-        self.failUnless(E_pass)
+        self.assertTrue(E_pass)
 
 suite = unittest.makeSuite(stack0, 'test')        
 

--- a/testsuite/stack1.py
+++ b/testsuite/stack1.py
@@ -56,7 +56,7 @@ class stack1(unittest.TestCase):
 
         free_tmps()
         
-        self.failUnless(n_pass and E_pass)
+        self.assertTrue(n_pass and E_pass)
 
 suite = unittest.makeSuite(stack1, 'test')        
 

--- a/testsuite/stack1.py
+++ b/testsuite/stack1.py
@@ -36,7 +36,7 @@ class stack1(unittest.TestCase):
 
         s = Stack(wg(0) + gap(1) + wg(0))
 
-        inc = zeros(N())
+        inc = np.zeros(N())
         inc[0] = 1
         s.set_inc_field(inc)
 

--- a/testsuite/stack2.py
+++ b/testsuite/stack2.py
@@ -52,7 +52,7 @@ class stack2(unittest.TestCase):
         set_lower_wall(slab_E_wall)
         set_upper_PML(0)
         
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(stack2, 'test')        
 

--- a/testsuite/substacks.py
+++ b/testsuite/substacks.py
@@ -50,7 +50,7 @@ class substacks(unittest.TestCase):
 
         free_tmps()
 
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 
 suite = unittest.makeSuite(substacks, 'test')        

--- a/testsuite/sudbo.py
+++ b/testsuite/sudbo.py
@@ -45,7 +45,7 @@ class sudbo(unittest.TestCase):
 
         free_tmps()
 
-        self.failUnless(n_eff_pass)
+        self.assertTrue(n_eff_pass)
 
 suite = unittest.makeSuite(sudbo, 'test')        
 

--- a/testsuite/surface_plasmon.py
+++ b/testsuite/surface_plasmon.py
@@ -69,7 +69,7 @@ class surface_plasmon(unittest.TestCase):
         set_mode_surplus(1.5)
         set_low_index_core(False)
 
-        self.failUnless(n_eff_pass)
+        self.assertTrue(n_eff_pass)
 
 suite = unittest.makeSuite(surface_plasmon, 'test')
 

--- a/testsuite/taper.py
+++ b/testsuite/taper.py
@@ -68,8 +68,8 @@ class taper(unittest.TestCase):
             
         s_inf = InfStack(e_inf)
 
-        rx = arange(0.0, (x_periods+1)*a, a/10.)
-        rz = arange(0.0, s.length(),      a/10.)
+        rx = np.arange(0.0, (x_periods+1)*a, a/10.)
+        rz = np.arange(0.0, s.length(),      a/10.)
 
         taper = Stack(e + s_inf)
       
@@ -79,7 +79,7 @@ class taper(unittest.TestCase):
 
         taper.calc()
 
-        inc=zeros(N())
+        inc=np.zeros(N())
         inc[0]=1
         taper.set_inc_field(inc)
 

--- a/testsuite/taper.py
+++ b/testsuite/taper.py
@@ -95,7 +95,7 @@ class taper(unittest.TestCase):
 
         set_upper_PML(0)
        
-        self.failUnless(R_pass)
+        self.assertTrue(R_pass)
 
 suite = unittest.makeSuite(taper, 'test')        
 

--- a/testsuite/w1reson.py
+++ b/testsuite/w1reson.py
@@ -14,8 +14,8 @@ class w1reson(unittest.TestCase):
     def create_w1_period(self,period,rad,periods,topbuf,matcore,matclad):
         tussen=sqrt(3)/2 *period
         tussen2 = sqrt(3)*period
-        numodd = periods/2
-        numeven = (periods+1)/2
+        numodd = int(periods/2)
+        numeven = int((periods+1)/2)
         propstart,propend,propprec = 0,2*rad+period/2,period/5
         transstart,transend,transprec = 0,tussen*periods+rad+topbuf,period/5
         gi = Geometry(matcore)
@@ -29,8 +29,8 @@ class w1reson(unittest.TestCase):
     def create_w1_1def_period(self,period,rad,defrad,periods,topbuf,matcore,matclad):
         tussen=sqrt(3)/2 *period
         tussen2 = sqrt(3)*period
-        numodd = periods/2
-        numeven = (periods+1)/2
+        numodd = int(periods/2)
+        numeven = int((periods+1)/2)
         propstart,propend,propprec = 0,2*rad+period/2,period/30
         transstart,transend,transprec = 0,tussen*periods+rad+topbuf,period/30
         gi = Geometry(matcore)

--- a/testsuite/w1reson.py
+++ b/testsuite/w1reson.py
@@ -101,7 +101,7 @@ class w1reson(unittest.TestCase):
     
         free_tmps()
 
-        self.failUnless(ta_pass and tp_pass and ra_pass and rp_pass)
+        self.assertTrue(ta_pass and tp_pass and ra_pass and rp_pass)
 
         set_solver(track)
         set_orthogonal(1)

--- a/testsuite/wg.py
+++ b/testsuite/wg.py
@@ -41,7 +41,7 @@ class wg(unittest.TestCase):
         set_upper_PML(0)
         set_lower_PML(0)
        
-        self.failUnless(n_pass)
+        self.assertTrue(n_pass)
 
 suite = unittest.makeSuite(wg, 'test')        
 

--- a/visualisation/TkPlotCanvas.py
+++ b/visualisation/TkPlotCanvas.py
@@ -7,8 +7,8 @@
 # Last revision: 2002-5-14
 #
 
-from Tkinter import *
-from Canvas import Line, CanvasText
+from tkinter import *
+#from Canvas import Line, CanvasText
 import string, numpy
 
 """This module provides a plot widget for Tk user interfaces.

--- a/visualisation/slab_plot.py
+++ b/visualisation/slab_plot.py
@@ -9,7 +9,7 @@
 
 from camfr import *
 from numpy import *
-from Tkinter import *
+from tkinter import *
 from TkPlotCanvas import *
 
 

--- a/visualisation/stack_plot.py
+++ b/visualisation/stack_plot.py
@@ -9,7 +9,7 @@
 
 from camfr import *
 from numpy import *
-from Tkinter import *
+from tkinter import *
 
 # win bug?? of toch ergens code die ik mis
 import camfr_PIL


### PR DESCRIPTION
fix numpy issue, dylib issue (#7), add requirement.txt, new machine_cfg.py for modern M1 MacOs with brew, misc compatibility fixes

works for me on Mac book pro M1 with python 3.9

the following tests fail with non compilation related errors
- `backward`, `teststack2`, `metal_splitter`

actually 4 other tests crash during execution:
- `PhC_splitter.py`, `fw_bw.py`, `gaussian.py`, `sudbo.py`

and I observed a rare, random exception on memory free again in c++ code

being investigated...